### PR TITLE
Filter "loop" devices out on Ubuntu

### DIFF
--- a/benja/utils
+++ b/benja/utils
@@ -66,7 +66,7 @@ findTheDisk() {
       fi
     done
   else
-    for disk in $(lsblk --output NAME); do
+    for disk in $(lsblk --output NAME | grep -v '^loop'); do
       if [ "$(echo $disk | sed -e 's/^[a-z]//')" != "$disk" ]; then
         ((i=i+1))
         disks="$disks $disk"


### PR DESCRIPTION
I have noticed that loop devices were added to the options, causing a selection issue because input only accounts for `read` hence picks up single key input.
On my VM there were plenty of `loop` devices 0 through 23, pushing `sdab` to position 26